### PR TITLE
feat: implement event-driven collision listening

### DIFF
--- a/public/js/ecs/comps/polygon2dCollider.js
+++ b/public/js/ecs/comps/polygon2dCollider.js
@@ -27,11 +27,11 @@ export const CollisionState = {
  */
 
 export default class Polygon2dCollider extends Polygon2d {
-  prevColState = CollisionState.NONE;
-  curColState = CollisionState.NONE;
+  prevState = CollisionState.NONE;
+  curState = CollisionState.NONE;
 
   /** @type {CollisionInfo} */
-  curColInfo = {
+  curInfo = {
     mtv: null,
     self: null,
     other: null,

--- a/public/js/ecs/comps/polygon2dCollider.js
+++ b/public/js/ecs/comps/polygon2dCollider.js
@@ -12,7 +12,7 @@ export const CollisionState = {
 
     if (num & 1) val.push('NONE');
     if (num & 2) val.push('ENTER');
-    if (num & 4) val.push('COLLIDING');
+    if (num & 4) val.push('STAY');
     if (num & 8) val.push('EXIT');
 
     return val.join(' & ');
@@ -22,19 +22,20 @@ export const CollisionState = {
 /**
  * @typedef {Object} CollisionInfo
  * @prop {import('../util/vector2d.js').default | null} mtv Minimum translation vector relative to self.
- * @prop {number | null} self
- * @prop {number | null} other
+ * @prop {number | null} otherEntId
+ * @prop {number} prevState
+ * @prop {number} state
  */
 
 export default class Polygon2dCollider extends Polygon2d {
-  prevState = CollisionState.NONE;
-  curState = CollisionState.NONE;
-
-  /** @type {CollisionInfo} */
-  curInfo = {
+  /**
+   * @type {CollisionInfo}
+   */
+  info = {
     mtv: null,
-    self: null,
-    other: null,
+    otherEntId: null,
+    prevState: CollisionState.NONE,
+    state: CollisionState.NONE,
   };
 
   /**

--- a/public/js/ecs/comps/polygon2dCollider.js
+++ b/public/js/ecs/comps/polygon2dCollider.js
@@ -3,9 +3,9 @@ import Polygon2d from './polygon2d.js';
 export const CollisionState = {
   NONE: 1,
   ENTER: 2,
-  COLLIDING: 4,
+  STAY: 4,
   EXIT: 8,
-  WIDE_COLLIDING: 2 | 4 | 8,
+  ALL: 2 | 4 | 8,
   /** @param {number} num  */
   toString(num) {
     const val = [];

--- a/public/js/ecs/systems/polygon2dCollision.js
+++ b/public/js/ecs/systems/polygon2dCollision.js
@@ -17,10 +17,10 @@ function updtColState(isColliding, collider) {
     collider.curColState =
       collider.prevColState & CollisionState.NONE
         ? CollisionState.ENTER
-        : CollisionState.COLLIDING;
+        : CollisionState.STAY;
   } else {
     collider.curColState =
-      collider.prevColState & CollisionState.COLLIDING
+      collider.prevColState & CollisionState.STAY
         ? CollisionState.EXIT
         : CollisionState.NONE;
   }

--- a/public/js/ecs/systems/polygon2dCollision.js
+++ b/public/js/ecs/systems/polygon2dCollision.js
@@ -9,19 +9,27 @@ import {
 } from './polygon2dCollision.util.js';
 
 /**
+ * @typedef {(data: {
+ *   mtv: import('../util/vector2d.js').default,
+ *   ent1: number,
+ *   ent2: number
+ * }) => void} CollisionEventListener
+ */
+
+/**
  * @param {number} prevState
  * @param {boolean} isColliding
  */
 function getNewState(prevState, isColliding) {
   if (isColliding) {
-    return prevState & CollisionState.NONE
-      ? CollisionState.ENTER
-      : CollisionState.STAY;
+    if (prevState === CollisionState.NONE) return CollisionState.ENTER;
+
+    return CollisionState.STAY;
   }
 
-  return prevState & CollisionState.STAY
-    ? CollisionState.EXIT
-    : CollisionState.NONE;
+  if (prevState === CollisionState.STAY) return CollisionState.EXIT;
+
+  return CollisionState.NONE;
 }
 
 export default class Polygon2dCollision extends Sys {
@@ -34,23 +42,14 @@ export default class Polygon2dCollision extends Sys {
   /**
    * @type {import('../core/sys.js').SysAction}
    */
-  fixedUpdate = ({ entMger }) => {
+  fixedUpdate = ({ entMger, evtBus }) => {
     /**
-     * Current frame cache; resets every frame.
+     * Contains the collisions that were already calculated.
+     * `main_ent_id => other_ent_id`
+     *
+     * @type {Map<number, Set<number>>}
      */
-    const fcache = {
-      /**
-       * Contains the collisions that were already calculated.
-       * `main_ent_id => other_ent_id`
-       *
-       * @type {Map<number, Set<number>>}
-       */
-      col: new Map(),
-      /**
-       * Contains the reset[ted] collision infos.
-       */
-      rst: new Set(),
-    };
+    const wasCalculated = new Map();
 
     for (const ent1 of entMger.getEntsWithComp_t(Polygon2dCollider)) {
       const col1 = entMger.getComp_t(ent1, Polygon2dCollider);
@@ -59,61 +58,84 @@ export default class Polygon2dCollision extends Sys {
       const t1 = entMger.getComp_t(ent1, Transform2d);
       if (!t1) continue;
 
-      // Reset ent1 if ent1 wasn't reset[ted] in the current frame.
-      if (!fcache.rst.has(ent1)) {
-        fcache.rst.add(ent1);
-        col1.info.prevState = col1.info.state;
-        col1.info.state = getNewState(col1.info.prevState, false);
-      }
-
       const nearbyEnts = entMger.getEntsWithComp_t(Polygon2dCollider);
       for (const ent2 of nearbyEnts) {
-        if (ent1 === ent2 || fcache.col.get(ent1)?.has(ent2)) continue;
+        if (ent1 === ent2 || wasCalculated.get(ent1)?.has(ent2)) {
+          continue;
+        }
 
         const col2 = entMger.getComp_t(ent2, Polygon2dCollider);
         const t2 = entMger.getComp_t(ent2, Transform2d);
         if (!col2 || !t2) continue;
 
         // Cache ent1 and ent2 interaction as having been calculated already.
-        if (!fcache.col.get(ent1)?.add(ent2))
-          fcache.col.set(ent1, new Set([ent2]));
-        if (!fcache.col.get(ent2)?.add(ent1))
-          fcache.col.set(ent2, new Set([ent1]));
+        if (!wasCalculated.get(ent1)?.add(ent2))
+          wasCalculated.set(ent1, new Set([ent2]));
+        if (!wasCalculated.get(ent2)?.add(ent1))
+          wasCalculated.set(ent2, new Set([ent1]));
 
-        if (
-          (col1.rules.mask & col2.rules.layer) === 0 &&
-          (col2.rules.mask & col1.rules.layer) === 0
-        )
+        const mtv = this.calcCollision(col1, t1, col2, t2);
+
+        if (!mtv) {
+          col1.trySetInfo(ent2, {
+            mtv: null,
+            other: ent2,
+            state: getNewState(col1.tryGetInfo(ent2).state, false),
+          });
+          col2.trySetInfo(ent1, {
+            mtv: null,
+            other: ent1,
+            state: getNewState(col2.tryGetInfo(ent1).state, false),
+          });
           continue;
+        }
 
-        if (!testBoundsBounds(col1.calcAabb(t1), col2.calcAabb(t2))) continue;
+        const info1 = {
+          mtv: mtv.cpy(),
+          other: ent2,
+          state: getNewState(col1.tryGetInfo(ent2).state, true),
+        };
+        col1.trySetInfo(ent2, info1);
 
-        const tc1 = col1.calcTransformed(t1);
-        const tc2 = col2.calcTransformed(t2);
+        const info2 = {
+          mtv: mtv.cpy().neg(),
+          other: ent1,
+          state: getNewState(col2.tryGetInfo(ent1).state, true),
+        };
+        col2.trySetInfo(ent1, info2);
 
-        const mtv = calcMinTranslationVec(tc1, tc2);
-        if (mtv) {
-          col1.info.state = getNewState(col1.info.prevState, true);
-          col1.info.otherEntId = ent2;
-          col1.info.mtv = mtv;
+        evtBus.emit(`collision_${CollisionState.toString(info1.state)}`, {
+          mtv,
+          ent1,
+          ent2,
+        });
 
-          // Reset ent2 if ent2 wasn't reset[ted] in the current frame.
-          if (!fcache.rst.has(ent2)) {
-            fcache.rst.add(ent2);
-            col2.info.prevState = col2.info.state;
-          }
-          
-          col2.info.state = getNewState(col1.info.prevState, true);
-          col2.info.otherEntId = ent1;
-          col2.info.mtv = mtv.neg();
-
-          if (this.isResolver && !col1.rules.phantom && !col2.rules.phantom) {
-            const mtvHalf = mtv.cpy().mul(0.5);
-            t1.pos.add(mtvHalf);
-            t2.pos.sub(mtvHalf);
-          }
+        if (this.isResolver && !col1.rules.phantom && !col2.rules.phantom) {
+          const mtvHalf = mtv.cpy().mul(0.8);
+          t1.pos.add(mtvHalf);
+          t2.pos.sub(mtvHalf);
         }
       }
     }
   };
+
+  /**
+   * @param {Polygon2dCollider} col1
+   * @param {Transform2d} t1
+   * @param {Polygon2dCollider} col2
+   * @param {Transform2d} t2
+   */
+  calcCollision(col1, t1, col2, t2) {
+    if (
+      ((col1.rules.mask & col2.rules.layer) === 0 &&
+        (col2.rules.mask & col1.rules.layer) === 0) ||
+      !testBoundsBounds(col1.calcAabb(t1), col2.calcAabb(t2))
+    )
+      return null;
+
+    return calcMinTranslationVec(
+      col2.calcTransformed(t2),
+      col1.calcTransformed(t1),
+    );
+  }
 }

--- a/public/js/ecs/systems/polygon2dCollision.js
+++ b/public/js/ecs/systems/polygon2dCollision.js
@@ -62,8 +62,8 @@ export default class Polygon2dCollision extends Sys {
       // Reset ent1 if ent1 wasn't reset[ted] in the current frame.
       if (!fcache.rst.has(ent1)) {
         fcache.rst.add(ent1);
-        col1.prevState = col1.curState;
-        col1.curState = CollisionState.NONE;
+        col1.info.prevState = col1.info.state;
+        col1.info.state = getNewState(col1.info.prevState, false);
       }
 
       const nearbyEnts = entMger.getEntsWithComp_t(Polygon2dCollider);
@@ -93,23 +93,19 @@ export default class Polygon2dCollision extends Sys {
 
         const mtv = calcMinTranslationVec(tc1, tc2);
         if (mtv) {
-          col1.curState = getNewState(col1.prevState, true);
-
-          col1.curInfo.self = ent1;
-          col1.curInfo.other = ent2;
-          col1.curInfo.mtv = mtv;
+          col1.info.state = getNewState(col1.info.prevState, true);
+          col1.info.otherEntId = ent2;
+          col1.info.mtv = mtv;
 
           // Reset ent2 if ent2 wasn't reset[ted] in the current frame.
           if (!fcache.rst.has(ent2)) {
             fcache.rst.add(ent2);
-            col2.prevState = col2.curState;
+            col2.info.prevState = col2.info.state;
           }
-
-          col2.curState = getNewState(col1.prevState, true);
-
-          col2.curInfo.self = ent2;
-          col2.curInfo.other = ent1;
-          col2.curInfo.mtv = mtv.neg();
+          
+          col2.info.state = getNewState(col1.info.prevState, true);
+          col2.info.otherEntId = ent1;
+          col2.info.mtv = mtv.neg();
 
           if (this.isResolver && !col1.rules.phantom && !col2.rules.phantom) {
             const mtvHalf = mtv.cpy().mul(0.5);

--- a/public/js/systems/hazardSys.js
+++ b/public/js/systems/hazardSys.js
@@ -1,29 +1,55 @@
 import HazardComp from '../comps/hazardComp.js';
 import HealthComp from '../comps/healthComp.js';
-import Polygon2dCollider, {
-  CollisionState,
-} from '../ecs/comps/polygon2dCollider.js';
+import Polygon2dCollider from '../ecs/comps/polygon2dCollider.js';
 import Sys from '../ecs/core/sys.js';
 
 export default class HazardSys extends Sys {
   /** @type {import("../ecs/core/sys.js").SysAction} */
-  fixedUpdate = ({ entMger }) => {
-    for (const ent of entMger.getEntsWithComp_t(HazardComp)) {
-      const hazard = entMger.getComp_t(ent, HazardComp);
-      const poly2dCol = entMger.getComp_t(ent, Polygon2dCollider);
-      if (!hazard || !poly2dCol) return;
+  start = ({ evtBus, entMger }) => {
+    evtBus.on(
+      'collision_enter',
+      /** @type {import('../ecs/systems/polygon2dCollision.js').CollisionEventListener} */
+      ({ ent1, ent2 }) => {
+        const $ = this.#structurizeEntities(entMger, ent1, ent2);
+        if (!$) return;
 
-      if (
-        poly2dCol.info.state & CollisionState.ENTER &&
-        poly2dCol.info.otherEntId
-      ) {
-        const other_health = entMger.getComp_t(ent, HealthComp);
-        if (!other_health) return;
-
-        other_health.curHp -= hazard.dmg;
-        if (other_health.curHp <= 0)
-          entMger.destroyEnt(poly2dCol.info.otherEntId);
-      }
-    }
+        $.other.health.curHp -= $.self.hazard.dmg;
+        if ($.other.health.curHp <= 0) entMger.destroyEnt($.other_id);
+      },
+    );
   };
+
+  /**
+   * @param {import('../ecs/core/entMger.js').default} entMger
+   * @param {number} ent1
+   * @param {number} ent2
+   */
+  #structurizeEntities(entMger, ent1, ent2) {
+    let self = ent1;
+    let other = ent2;
+    let hazard = entMger.getComp_t(self, HazardComp);
+    if (!hazard) {
+      self = ent2;
+      other = ent1;
+
+      hazard = entMger.getComp_t(self, HazardComp);
+      if (!hazard) return null;
+    }
+
+    const poly2dCol = entMger.getComp_t(self, Polygon2dCollider);
+    const other_health = entMger.getComp_t(other, HealthComp);
+    if (!poly2dCol || !other_health) return null;
+
+    return {
+      self_id: self,
+      self: {
+        hazard,
+        poly2dCol,
+      },
+      other_id: other,
+      other: {
+        health: other_health,
+      },
+    };
+  }
 }

--- a/public/js/systems/hazardSys.js
+++ b/public/js/systems/hazardSys.js
@@ -14,18 +14,15 @@ export default class HazardSys extends Sys {
       if (!hazard || !poly2dCol) return;
 
       if (
-        poly2dCol.curState & CollisionState.ENTER &&
-        poly2dCol.curInfo.other
+        poly2dCol.info.state & CollisionState.ENTER &&
+        poly2dCol.info.otherEntId
       ) {
-        const other_health = entMger.getComp_t(
-          poly2dCol.curInfo.other,
-          HealthComp,
-        );
+        const other_health = entMger.getComp_t(ent, HealthComp);
         if (!other_health) return;
 
         other_health.curHp -= hazard.dmg;
         if (other_health.curHp <= 0)
-          entMger.destroyEnt(poly2dCol.curInfo.other);
+          entMger.destroyEnt(poly2dCol.info.otherEntId);
       }
     }
   };

--- a/public/js/systems/hazardSys.js
+++ b/public/js/systems/hazardSys.js
@@ -14,18 +14,18 @@ export default class HazardSys extends Sys {
       if (!hazard || !poly2dCol) return;
 
       if (
-        poly2dCol.curColState & CollisionState.ENTER &&
-        poly2dCol.curColInfo.other
+        poly2dCol.curState & CollisionState.ENTER &&
+        poly2dCol.curInfo.other
       ) {
         const other_health = entMger.getComp_t(
-          poly2dCol.curColInfo.other,
+          poly2dCol.curInfo.other,
           HealthComp,
         );
         if (!other_health) return;
 
         other_health.curHp -= hazard.dmg;
         if (other_health.curHp <= 0)
-          entMger.destroyEnt(poly2dCol.curColInfo.other);
+          entMger.destroyEnt(poly2dCol.curInfo.other);
       }
     }
   };


### PR DESCRIPTION
The primary goal of this pull request was to enable event-driven collision handling. However, while developing, it led to improvements in the collision system, allowing a system to listen to multiple collisions and, consequently, fixed a bug where an entity wouldn't enter a "enter" state with another entity if it was already colliding with an existing entity.